### PR TITLE
Fix cryptic 'endswith' error when an image is not set for chapter

### DIFF
--- a/pages/_story.vue
+++ b/pages/_story.vue
@@ -37,6 +37,9 @@
           </div>
         </div>
       </div>
+      <div v-else>
+        <p> No image found for this chapter. Does the chapter tag for this story have an image key? e.g. :::Chapter{headline="Name of my chapter" image="chapimg.png"} </p>
+      </div>
     </div>
   </div>
 </template>

--- a/pages/_story.vue
+++ b/pages/_story.vue
@@ -28,7 +28,7 @@
           For more information on editing stories, see <a href="https://blog.esciencecenter.nl/storyboards-for-science-communication-85e399e5c1b5" target="_blank">this blog post</a>.
         </p>
       </div>
-      <div class="w-2/3 bg-white rounded">
+      <div v-if="chapter.props.hasOwnProperty('image')" class="w-2/3 bg-white rounded">
         <img v-if="!chapter.props.image.endsWith('html')" :src="getContent(chapter.props.image)" alt="story image" class="object-contain w-auto h-full max-w-full max-h-full mx-auto" @click="openBigImage">
         <iframe v-else :src="getContent(chapter.props.image)" frameborder="0" class="w-full h-full" />
         <div v-show="showBigImage" v-if="!chapter.props.image.endsWith('html')" class="fixed inset-0 flex bg-gray-900 bg-opacity-80" @click="closeBigImage">


### PR DESCRIPTION
An unhelpful error was displayed in the browser if the 'Chapter' line in a story's markdown did not specify an image file.

For example:
`:::Chapter{headline="Citation"}` instead of `:::Chapter{headline="Citation" image="ghlogo.png"}`

Firefox gave a somewhat understandable error but in Chromium it was not so obvious. I have added a slightly more graceful error handling, in which the page is still able to render, but the media pane div displays an error and a potential fix.

Tested in both firefox 109.0.1 and chromium 109.0.5414.119

Fixes https://github.com/esciencecenter-digital-skills/software-support-essentials/issues/9