### PR TITLE
Move hidden stories to upcoming category and unhide

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 
 {
     "title": "Essentials for Research Software Support",
-    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Resources", "Examples"],
+    "categoryOrder": ["Getting started", "Reusability", "Publishing & Citing", "Resources", "Examples", "Upcoming (under construction)"],
     "another": ""
 }

--- a/static/stories/documentation.md
+++ b/static/stories/documentation.md
@@ -1,18 +1,17 @@
 ---
 id: 1
 trl: medium
-category: Reusability
+category: Upcoming (under construction)
 title: Documentation
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Documentation" widemd=1}
 ## Documentation
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
 
-https://www.nature.com/articles/s41598-022-10376-9
 
 :::

--- a/static/stories/environments.md
+++ b/static/stories/environments.md
@@ -1,23 +1,16 @@
 ---
 id: 2
 trl: medium
-category: Resources
+category: Upcoming (under construction)
 title: Environments & Containers
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Environments" widemd=1}
-## Environments
+## Environments & Containers
 
-conda
-pip
-binder
-:::
+This module is still under development
 
-:::Chapter{headline="Containers"  widemd=1}
-## Containers
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 :::

--- a/static/stories/hpc.md
+++ b/static/stories/hpc.md
@@ -1,15 +1,16 @@
 ---
 id: 4
 trl: medium
-category: Resources
-title: HPC
+category: Upcoming (under construction)
+title: High Performance Computing (HPC)
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="High Performance Cluster" widemd=1}
 ## High Performance Cluster (HPC)
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
+
 :::

--- a/static/stories/notebooks.md
+++ b/static/stories/notebooks.md
@@ -1,15 +1,16 @@
 ---
 id: 6
 trl: medium
-category: Reusability
+category: Upcoming (under construction)
 title: Notebooks
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Notebooks" widemd=1}
 ## Notebooks
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
+
 :::

--- a/static/stories/organization.md
+++ b/static/stories/organization.md
@@ -1,26 +1,16 @@
 ---
 id: 7
 trl: high
-category: Getting started
+category: Upcoming (under construction)
 title: Project organization
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Project organization" widemd=1}
 ## Project organization
-Different project organization structures
 
-e.g. data science, software package; also use of sourced subpackages
-
-:::
-
-:::Chapter{headline="Software packages" widemd=1}
-## Software packages
-
-Packaging software requires specific structures
-
-Use of template structures with e.g. cookiecutter
+This module is still under development
 
 :::

--- a/static/stories/testing.md
+++ b/static/stories/testing.md
@@ -1,21 +1,22 @@
 ---
 id: 9
 trl: medium
-category: Resources
+category: Upcoming (under construction)
 title: Testing & CI/CD
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Testing" widemd=1}
 ## Testing
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
+
 :::
 
 :::Chapter{headline="CI/CD" widemd=1}
 ## CI/CD
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
 :::

--- a/static/stories/version-control.md
+++ b/static/stories/version-control.md
@@ -1,24 +1,24 @@
 ---
 id: 10
 trl: high
-category: Getting started
+category: Upcoming (under construction)
 title: Version control, git and github
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Version control" widemd=1}
 ## Local version control
-Why version control is needed, and what systems exist
 
-distributed VC
+This module is still under development
+
 
 :::
 
 :::Chapter{headline="Remote repositories" widemd=1}
 ## Remote repositories
 
-Gitlab, github, bitbucket
+This module is still under development
 
 :::

--- a/static/stories/versioning.md
+++ b/static/stories/versioning.md
@@ -1,15 +1,16 @@
 ---
 id: 3
 trl: medium
-category: Publishing & Citing
+category: Upcoming (under construction)
 title: Versioning & Changelog
 author: eScience Center
 thumbnail: "nlesc-dummy.png"
-visibility: hidden
+visibility: visible
 ---
 
 :::Chapter{headline="Versioning" widemd=1}
 ## Versioning
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This module is still under development
+
 :::


### PR DESCRIPTION
We figured that at the moment it would be nice for people interested in the platform to know which modules are still in the planning.

- This PR moves all stories to that new category "Upcoming (under construction)" and places this new category at the bottom.
- All stories except for the "multimedia" example story are made visible.
- Any content in the upcoming stories was moved to the respective issue comment and a temporary message was put in the content of each of the stories.


closes #95 